### PR TITLE
Add version to generated package.json wrapper used for caching

### DIFF
--- a/src/bundling.js
+++ b/src/bundling.js
@@ -753,6 +753,7 @@ const bundling = {
                 name: orgPkgContents.name,
                 title: orgPkgContents.title,
                 description: orgPkgContents.description,
+                version: orgPkgContents.version,
                 technical: true,
                 bundledFeatures: {}
             }


### PR DESCRIPTION
This allows to run npm pack in the dist folder.