### PR TITLE
Fix mixin-deep security alert using resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "typescript": "3.1.3",
     "vuepress": "1.2.0"
   },
+  "resolutions": {
+    "**/mixin-deep": "^1.3.2"
+  },
   "scripts": {
     "ci_full_flow": "npm-run-all format_validate type_check lint test docs website:build",
     "release": "node scripts/release.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6332,9 +6332,10 @@ mississippi@^3.0.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
-mixin-deep@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+mixin-deep@^1.2.0, mixin-deep@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
+  integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"


### PR DESCRIPTION
mixin-deep come from vuepress - which is already in the latest version.
The 'resolutions' mechanism allows requesting version range for a dependent component, without changing the generated yarn.lock